### PR TITLE
Feature/wcon 24 pathbrowser

### DIFF
--- a/editor/bundle/src/main/java/io/wcm/caconfig/editor/EditorProperties.java
+++ b/editor/bundle/src/main/java/io/wcm/caconfig/editor/EditorProperties.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2017 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caconfig.editor;
+
+/**
+ * Properties that can be used for configuration property definitions to customize the edit widget within the editor.
+ */
+public final class EditorProperties {
+
+  private EditorProperties() {
+    // constants only
+  }
+
+  /**
+   * Property name for defining the widget type. Values should be one of the WIDGET_TYPE_* properties.
+   */
+  public static final String PROPERTY_WIDGET_TYPE = "widgetType";
+
+  /**
+   * Widget type to add a pathbrowser selection widget to a string parameter.
+   */
+  public static final String WIDGET_TYPE_PATHBROWSER = "pathbrowser";
+
+  /**
+   * With this additional property the root path for the path browser widget can be set.
+   */
+  public static final String PROPERTY_PATHBROWSER_ROOT_PATH = "pathbrowserRootPath";
+
+}

--- a/editor/bundle/src/main/java/io/wcm/caconfig/editor/package-info.java
+++ b/editor/bundle/src/main/java/io/wcm/caconfig/editor/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2017 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * Configuration editor API.
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package io.wcm.caconfig.editor;

--- a/editor/bundle/src/main/resources/angularjs-partials/parameterValue.html
+++ b/editor/bundle/src/main/resources/angularjs-partials/parameterValue.html
@@ -10,6 +10,10 @@
            ng-disabled="true" ng-readonly="true" />
   </div>
 
+  <div ng-switch-when="pathbrowser">
+    <caconfig-pathbrowser parameter="parameter" root-path="{{rootPath}}" />
+  </div>
+
   <div ng-switch-when="number">
     <input class="coral-Textfield" type="text"
            ng-hide="parameter.overridden || parameter.inherited"

--- a/editor/bundle/src/main/resources/angularjs-partials/parameterValue.html
+++ b/editor/bundle/src/main/resources/angularjs-partials/parameterValue.html
@@ -11,7 +11,7 @@
   </div>
 
   <div ng-switch-when="pathbrowser">
-    <caconfig-pathbrowser parameter="parameter" root-path="{{rootPath}}" />
+    <caconfig-pathbrowser parameter="parameter" />
   </div>
 
   <div ng-switch-when="number">

--- a/editor/bundle/src/main/resources/angularjs-partials/pathbrowser.html
+++ b/editor/bundle/src/main/resources/angularjs-partials/pathbrowser.html
@@ -1,0 +1,10 @@
+<div class="caconfig-pathbrowser">
+    <!-- TODO: ng-hide="parameter.overridden || parameter.inherited" -->
+    <span class="coral-PathBrowser" data-init="pathbrowser" data-option-loader="granite.ui.pathBrowser.pages.hierarchyNotFile" data-picker-src="/libs/wcm/core/content/common/pathbrowser/column.html/content?predicate=hierarchyNotFile">
+    <input class="coral-InputGroup-input coral-Textfield js-coral-pathbrowser-input" type="text"
+       ng-model="parameter.value" autocomplete="off"/>
+    <button class="coral-Button coral-Button--square js-coral-pathbrowser-button" type="button" title="Browse" ng-click="choosePath()">
+    <i class="coral-Icon coral-Icon--sizeS coral-Icon--folderSearch"></i>
+    </button>
+</span>
+</div>

--- a/editor/bundle/src/main/resources/angularjs-partials/pathbrowser.html
+++ b/editor/bundle/src/main/resources/angularjs-partials/pathbrowser.html
@@ -1,10 +1,12 @@
 <div class="caconfig-pathbrowser">
-    <!-- TODO: ng-hide="parameter.overridden || parameter.inherited" -->
-    <span class="coral-PathBrowser" data-init="pathbrowser" data-option-loader="granite.ui.pathBrowser.pages.hierarchyNotFile" data-picker-src="/libs/wcm/core/content/common/pathbrowser/column.html/content?predicate=hierarchyNotFile">
-    <input class="coral-InputGroup-input coral-Textfield js-coral-pathbrowser-input" type="text"
-       ng-model="parameter.value" autocomplete="off"/>
-    <button class="coral-Button coral-Button--square js-coral-pathbrowser-button" type="button" title="Browse" ng-click="choosePath()">
-    <i class="coral-Icon coral-Icon--sizeS coral-Icon--folderSearch"></i>
-    </button>
-</span>
+    <span class="coral-PathBrowser">
+        <span class="coral-InputGroup coral-InputGroup--block">
+            <input class="coral-InputGroup-input coral-Textfield js-coral-pathbrowser-input" type="text" autocomplete="off" ng-model="parameter.value"/>
+            <span class="coral-InputGroup-button">
+                <button class="coral-Button coral-Button--square js-coral-pathbrowser-button" type="button" title="{{i18n.button.browse}}">
+                    <i class="coral-Icon coral-Icon--sizeS coral-Icon--folderSearch"></i>
+                </button>
+            </span>
+        </span>
+    </span>
 </div>

--- a/editor/bundle/src/main/resources/i18n/de.json
+++ b/editor/bundle/src/main/resources/i18n/de.json
@@ -12,7 +12,8 @@
       "discard": "Änderungen verwefen",
       "edit": "Bearbeiten",
       "ok": "OK",
-      "save": "Speichern"
+      "save": "Speichern",
+      "browse": "Durchsuchen"
     },
     "config": {
       "name": "Konfigurations-Name",

--- a/editor/bundle/src/main/resources/i18n/en.json
+++ b/editor/bundle/src/main/resources/i18n/en.json
@@ -12,7 +12,8 @@
       "discard": "Discard Changes",
       "edit": "Edit",
       "ok": "OK",
-      "save": "Save"
+      "save": "Save",
+      "browse": "Browse"
     },
     "config": {
       "name": "Configuration Name",

--- a/editor/bundle/src/main/webapp/app-root/components/page/editor/html.html
+++ b/editor/bundle/src/main/webapp/app-root/components/page/editor/html.html
@@ -43,7 +43,8 @@
                 discard: "${'io.wcm.caconfig.editor.button.discard' @ i18n, context='text'}",
                 edit: "${'io.wcm.caconfig.editor.button.edit' @ i18n, context='text'}",
                 ok: "${'io.wcm.caconfig.editor.button.ok' @ i18n, context='text'}",
-                save: "${'io.wcm.caconfig.editor.button.save' @ i18n, context='text'}"
+                save: "${'io.wcm.caconfig.editor.button.save' @ i18n, context='text'}",
+                browse: "${'io.wcm.caconfig.editor.button.browse' @ i18n, context='text'}"
               },
               config: {
                 name: "${'io.wcm.caconfig.editor.config.name' @ i18n, context='text'}",

--- a/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/css/editor.css
+++ b/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/css/editor.css
@@ -62,6 +62,10 @@ span.caconfig-pathbrowser {
   right: 0;
 }
 
+.caconfig-pathbrowser .coral-PathBrowser {
+  width: 100%;
+}
+
 .wcm-io-editor.endor-Brand {
   display: inline-block;
   background-color: transparent;

--- a/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js.txt
+++ b/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js.txt
@@ -27,5 +27,6 @@ widgets/widgets.module.js
 widgets/widgets.constants.js
 widgets/description-popup.directive.js
 widgets/multifield.directive.js
+widgets/pathbrowser.directive.js
 widgets/parameter-value.directive.js
 widgets/popup-content.directive.js

--- a/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/parameter-value.directive.js
+++ b/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/parameter-value.directive.js
@@ -61,6 +61,10 @@
       else if (scope.parameter.metadata && scope.parameter.metadata.multivalue) {
         scope.type = "multivalue";
       }
+      else if (scope.parameter.metadata.properties && scope.parameter.metadata.properties.widgetType === "pathbrowser") {
+        scope.type = "pathbrowser";
+        scope.rootPath = scope.parameter.metadata.properties.pathbrowserRootPath || "/content";
+      }
       else if (scope.parameter.metadata && scope.parameter.metadata.type) {
         input = inputMap[scope.parameter.metadata.type];
         scope.type = input.type || scope.parameter.metadata.type;

--- a/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/parameter-value.directive.js
+++ b/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/parameter-value.directive.js
@@ -61,9 +61,8 @@
       else if (scope.parameter.metadata && scope.parameter.metadata.multivalue) {
         scope.type = "multivalue";
       }
-      else if (scope.parameter.metadata.properties && scope.parameter.metadata.properties.widgetType === "pathbrowser") {
+      else if (scope.parameter.metadata && scope.parameter.metadata.properties && scope.parameter.metadata.properties.widgetType === "pathbrowser") {
         scope.type = "pathbrowser";
-        scope.rootPath = scope.parameter.metadata.properties.pathbrowserRootPath || "/content";
       }
       else if (scope.parameter.metadata && scope.parameter.metadata.type) {
         input = inputMap[scope.parameter.metadata.type];

--- a/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
+++ b/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
@@ -50,7 +50,8 @@
       var props = scope.parameter.metadata.properties;
       var options = {};
       for (var prop in props) {
-          if (prop && prop.substring(0, prefix.length) != -1) {
+          // if the property starts with the prefix "pathbrowser" followed by a pathbrowser property name
+          if (prop && prop.length > prefix.length && prop.substring(0, prefix.length) != -1) {
               var propName = prop.substring(prefix.length);
               options[propName.charAt(0).toLowerCase() + propName.slice(1)] = props[prop];
           }

--- a/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
+++ b/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/pathbrowser.directive.js
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2016 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+(function (angular, _) {
+  "use strict";
+  angular.module("io.wcm.caconfig.widgets")
+      .directive("caconfigPathbrowser", pathbrowser);
+
+  pathbrowser.$inject = ["templateUrlList", "inputMap"];
+
+  function pathbrowser(templateList, inputMap) {
+    var directive = {
+      restrict: "E",
+      replace: true,
+      require: "^form",
+      templateUrl: templateList.pathbrowser,
+      scope: {
+        parameter: "="
+      },
+      controller: PathbrowserController,
+      link: link
+    };
+
+    return directive;
+
+    function link(scope, element, attr, form) {
+      var input = inputMap[scope.parameter.metadata.type];
+      var inheritedStateChanged = false;
+
+      scope.type = input.type;
+      scope.pattern = input.pattern;
+
+      scope.$watch("parameter.inherited", function (isInherited, wasInherited) {
+        if (isInherited === wasInherited) {
+          return;
+        }
+
+        inheritedStateChanged = true;
+        form.$setDirty();
+      });
+    }
+  }
+
+  PathbrowserController.$inject = ["$scope"];
+
+  function PathbrowserController($scope) {
+    $scope.choosePath = function () {
+      /*
+      $scope.$evalAsync(function () {
+        $scope.values.splice(index + 1, 0, { value: undefined });
+      });
+      */
+    };
+  }
+}(angular, _));

--- a/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/widgets.constants.js
+++ b/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/widgets.constants.js
@@ -33,7 +33,8 @@
       parameterValue: "parameterValue.html",
       popupContainer: "popupContainer.html",
       popupContent: "popupContent.html",
-      multifield: "multifield.html"
+      multifield: "multifield.html",
+      pathbrowser: "pathbrowser.html"
     })
     .constant("inputMap", {
       Boolean: {

--- a/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/widgets.constants.js
+++ b/editor/bundle/src/main/webapp/clientlibs-root/io.wcm.caconfig.editor/js/widgets/widgets.constants.js
@@ -36,6 +36,9 @@
       multifield: "multifield.html",
       pathbrowser: "pathbrowser.html"
     })
+    .constant("directivePropertyPrefixes", {
+      pathbrowser: "pathbrowser"
+    })
     .constant("inputMap", {
       Boolean: {
         type: "checkbox",

--- a/sample-app/bundles/base/src/main/java/io/wcm/caconfig/sample/config/ConfigSample.java
+++ b/sample-app/bundles/base/src/main/java/io/wcm/caconfig/sample/config/ConfigSample.java
@@ -47,6 +47,15 @@ public @interface ConfigSample {
   boolean boolParam();
 
   /**
+   * @return Path parameter
+   */
+  @Property(label = "Path", description = "String parameter using path browser widget.", order = 4, property = {
+      "widgetType=pathbrowser",
+      "pathbrowserRootPath=/content/dam"
+  })
+  String path();
+
+  /**
    * @return String array parameter with default value
    */
   @Property(label = "String Array Param", order = 4)


### PR DESCRIPTION
Added a working implementation for the pathbrowser.

- Styling so it looks slick
- i18n support
- Properties are being read from the pathbrowser* settings from the Sling CA-Config Property annotation
- Fixed load auto complete
- Fixed PathbrowserPicker

Didn't check the inheritance / multifield feature of the editor for a pathbrowser