### PR TITLE
Feature/WCON-38

### DIFF
--- a/extensions/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PersistenceUtils.java
+++ b/extensions/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PersistenceUtils.java
@@ -45,7 +45,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.replication.AccessDeniedException;
 import com.day.cq.wcm.api.NameConstants;
+import com.day.cq.wcm.api.WCMException;
 
 final class PersistenceUtils {
 
@@ -234,6 +236,15 @@ final class PersistenceUtils {
     catch (PersistenceException ex) {
       throw convertPersistenceException("Unable to persist configuration changes to " + relatedResourcePath, ex);
     }
+  }
+
+  public static ConfigurationPersistenceException convertWCMException(String message, WCMException ex) {
+    String causeClsName = ex.getCause().getClass().getName();
+    if (StringUtils.equals(causeClsName, "com.day.cq.replication.AccessDeniedException")
+            || StringUtils.equals(causeClsName, "javax.jcr.AccessDeniedException")) {
+      return new ConfigurationPersistenceAccessDeniedException("No write access: " + message, ex);
+    }
+    return new ConfigurationPersistenceException(message, ex);
   }
 
   public static ConfigurationPersistenceException convertPersistenceException(String message, PersistenceException ex) {

--- a/extensions/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
+++ b/extensions/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
@@ -26,15 +26,17 @@ import com.day.cq.wcm.api.reference.Reference;
 import com.day.cq.wcm.api.reference.ReferenceProvider;
 
 /**
+ * <p>
  * This implementation of {@link ReferenceProvider} allows to resolve references of a given {@link Resource} to context-aware
  * configurations.
- *
+ * </p>
+ * <p>
  * This is for example used by ActivationReferenceSearchServlet to resolve referenced content of pages during activation of a page using
  * AEM sites. Returning the configurations allows the editor to activate them along with the page referring to them.
- *
+ * </p>
+ * <p>
  * This component can be disabled by configuration, but its enabled by default.
- *
- * @author Dirk Rudolph <dirk.rudolph@netcentric.biz>
+ * </p>
  */
 @Component(service = ReferenceProvider.class)
 @Designate(ocd = ConfigurationReferenceProvider.Config.class)

--- a/extensions/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
+++ b/extensions/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
@@ -1,0 +1,105 @@
+package io.wcm.caconfig.extensions.references.impl;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.caconfig.management.ConfigurationData;
+import org.apache.sling.caconfig.management.ConfigurationManager;
+import org.apache.sling.caconfig.spi.metadata.ConfigurationMetadata;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.reference.Reference;
+import com.day.cq.wcm.api.reference.ReferenceProvider;
+
+/**
+ * This implementation of {@link ReferenceProvider} allows to resolve references of a given {@link Resource} to context-aware
+ * configurations.
+ *
+ * This is for example used by ActivationReferenceSearchServlet to resolve referenced content of pages during activation of a page using
+ * AEM sites. Returning the configurations allows the editor to activate them along with the page referring to them.
+ *
+ * This component can be disabled by configuration, but its enabled by default.
+ *
+ * @author Dirk Rudolph <dirk.rudolph@netcentric.biz>
+ */
+@Component(service = ReferenceProvider.class)
+@Designate(ocd = ConfigurationReferenceProvider.Config.class)
+public class ConfigurationReferenceProvider implements ReferenceProvider {
+
+    @ObjectClassDefinition(name = "wcm.io Context-Aware Configuration Reference Provider",
+            description = "Allows to resolve references from resources to their Context-Aware configurations, for example during page activation.")
+    static @interface Config {
+
+        @AttributeDefinition(name = "Enabled",
+                description = "Enable this reference provider.")
+        boolean enabled() default true;
+    }
+
+    @org.osgi.service.component.annotations.Reference
+    private ConfigurationManager configurationManager;
+
+    private boolean enabled = false;
+
+    @Activate
+    protected void activate(Config config) {
+        enabled = config.enabled();
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        enabled = false;
+    }
+
+    @Override
+    public List<Reference> findReferences(Resource resource) {
+        if (!enabled) {
+            return Collections.emptyList();
+        }
+
+        Set<String> configurationNames = configurationManager.getConfigurationNames();
+        List<Reference> references = new ArrayList<>(configurationNames.size());
+        ResourceResolver resourceResolver = resource.getResourceResolver();
+
+        for(String configurationName : configurationNames) {
+            ConfigurationData configurationData = configurationManager.getConfiguration(resource, configurationName);
+            ConfigurationMetadata configurationMetadata = configurationManager.getConfigurationMetadata(configurationName);
+            Resource configurationResource = resourceResolver.getResource(configurationData.getResourcePath());
+
+            if (configurationResource != null) {
+                references.add(new Reference(getType(), StringUtils.defaultIfEmpty(configurationMetadata.getLabel(),
+                        configurationMetadata.getName()), configurationResource, getLastModifiedOf(configurationResource)));
+            }
+        }
+
+        return references;
+    }
+
+    private static long getLastModifiedOf(Resource configurationResource) {
+        Page configurationPage = configurationResource.adaptTo(Page.class);
+
+        if (configurationPage != null) {
+            return configurationPage.getLastModified().getTimeInMillis();
+        } else {
+            ValueMap properties = configurationResource.getValueMap();
+            return properties.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class).getTimeInMillis();
+        }
+    }
+
+    private static String getType() {
+        return "caconfig";
+    }
+}

--- a/extensions/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
+++ b/extensions/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
@@ -22,6 +22,8 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.PageManagerFactory;
 import com.day.cq.wcm.api.reference.Reference;
 import com.day.cq.wcm.api.reference.ReferenceProvider;
 
@@ -53,6 +55,9 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
 
     @org.osgi.service.component.annotations.Reference
     private ConfigurationManager configurationManager;
+
+    @org.osgi.service.component.annotations.Reference
+    private PageManagerFactory pageManagerFactory;
 
     private boolean enabled = false;
 
@@ -90,10 +95,14 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
         return references;
     }
 
-    private static long getLastModifiedOf(Resource configurationResource) {
+    private long getLastModifiedOf(Resource configurationResource) {
         Page configurationPage = configurationResource.adaptTo(Page.class);
 
-        if (configurationPage != null) {
+        if (configurationPage == null && StringUtils.equals(configurationResource.getName(), JcrConstants.JCR_CONTENT)) {
+            configurationPage = configurationResource.getParent().adaptTo(Page.class);
+        }
+
+        if (configurationPage != null && configurationPage.getLastModified() != null) {
             return configurationPage.getLastModified().getTimeInMillis();
         } else {
             ValueMap properties = configurationResource.getValueMap();

--- a/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationA.java
+++ b/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationA.java
@@ -1,0 +1,9 @@
+package io.wcm.caconfig.extensions.references.impl;
+
+import org.apache.sling.caconfig.annotation.Configuration;
+
+@Configuration(name = "configA", label = "Configuration A")
+@interface ConfigurationA {
+
+    String key() default "";
+}

--- a/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationB.java
+++ b/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationB.java
@@ -1,0 +1,9 @@
+package io.wcm.caconfig.extensions.references.impl;
+
+import org.apache.sling.caconfig.annotation.Configuration;
+
+@Configuration(name = "configB", label = "Configuration B")
+@interface ConfigurationB {
+
+    String key() default "";
+}

--- a/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProviderTest.java
+++ b/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProviderTest.java
@@ -1,0 +1,129 @@
+package io.wcm.caconfig.extensions.references.impl;
+
+import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.caconfig.impl.metadata.AnnotationClassParser;
+import org.apache.sling.caconfig.management.ConfigurationManager;
+import org.apache.sling.caconfig.spi.ConfigurationMetadataProvider;
+import org.apache.sling.caconfig.spi.ConfigurationPersistData;
+import org.apache.sling.caconfig.spi.metadata.ConfigurationMetadata;
+import org.apache.sling.testing.mock.osgi.MockOsgi;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.reference.Reference;
+import com.day.cq.wcm.api.reference.ReferenceProvider;
+import com.google.common.collect.ImmutableMap;
+
+import io.wcm.caconfig.extensions.persistence.impl.PagePersistenceStrategy;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import io.wcm.testing.mock.aem.junit.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit.AemContextCallback;
+
+public class ConfigurationReferenceProviderTest {
+
+    @Rule
+    public AemContext aemContext = new AemContextBuilder()
+            .beforeSetUp(new AemContextCallback() {
+                @Override
+                public void execute(AemContext ctx) {
+                    // also find sling:configRef props in cq:Page/jcr:content nodes
+                    MockOsgi.setConfigForPid(ctx.bundleContext(), "org.apache.sling.caconfig.resource.impl.def.DefaultContextPathStrategy",
+                            "configRefResourceNames", new String[] { "jcr:content", "." });
+                }
+            })
+            .plugin(CACONFIG)
+            .build();
+
+    private static final ValueMap configurationA = new ValueMapDecorator(ImmutableMap.of("key", "foo"));
+    private static final ValueMap configurationB = new ValueMapDecorator(ImmutableMap.of("key", "bar"));
+
+
+
+    @Before
+    public void setup() {
+        aemContext.create().resource("/conf");
+        Page page1 = aemContext.create().page("/content/site1/page", "pagetemplate", ImmutableMap.of("sling:configRef", "/conf/test/site1"));
+        Page page2 = aemContext.create().page("/content/site2/page", "pagetemplate", ImmutableMap.of("sling:configRef", "/conf/test/site2"));
+
+        TestConfigurationMetadataProvider metadataProvider = new TestConfigurationMetadataProvider();
+        metadataProvider.addConfigurationClass(ConfigurationA.class);
+        metadataProvider.addConfigurationClass(ConfigurationB.class);
+
+        aemContext.registerInjectActivateService(new PagePersistenceStrategy(), "enabled", true);
+        aemContext.registerService(ConfigurationMetadataProvider.class, metadataProvider);
+
+        applyConfig(page1, "configA", configurationA); // 1 config on page1
+        applyConfig(page2, "configA", configurationA); // 2 configs on page2
+        applyConfig(page2, "configB", configurationB);
+    }
+
+    @Test
+    public void testReferencesOfPage1() {
+        ReferenceProvider referenceProvider = new ConfigurationReferenceProvider();
+        aemContext.registerInjectActivateService(referenceProvider);
+        List<Reference> references = referenceProvider.findReferences(aemContext.resourceResolver().getResource("/content/site1/page"));
+        assertEquals(1, references.size());
+    }
+
+    @Test
+    public void testReferencesOfPage2() {
+        ReferenceProvider referenceProvider = new ConfigurationReferenceProvider();
+        aemContext.registerInjectActivateService(referenceProvider);
+        List<Reference> references = referenceProvider.findReferences(aemContext.resourceResolver().getResource("/content/site2/page"));
+        assertEquals(2, references.size());
+    }
+
+    @Test
+    public void testDisabled() {
+        ReferenceProvider referenceProvider = new ConfigurationReferenceProvider();
+        aemContext.registerInjectActivateService(referenceProvider, "enabled", false);
+        List<Reference> references = referenceProvider.findReferences(aemContext.resourceResolver().getResource("/content/site1/page"));
+        assertEquals(0, references.size());
+    }
+
+    private void applyConfig(Page p, String name, ValueMap values) {
+        ConfigurationManager configManager = aemContext.getService(ConfigurationManager.class);
+        Resource contextResource = p.adaptTo(Resource.class);
+        configManager.persistConfiguration(contextResource, name, new ConfigurationPersistData(values));
+    }
+
+    private static class TestConfigurationMetadataProvider implements ConfigurationMetadataProvider {
+
+        private final Map<String, ConfigurationMetadata> metadata = new HashMap<>();
+
+        void addConfigurationClass(Class<?> cls) {
+            metadata.put(AnnotationClassParser.getConfigurationName(cls), AnnotationClassParser.buildConfigurationMetadata(cls));
+        }
+
+        @Nonnull
+        @Override
+        public SortedSet<String> getConfigurationNames() {
+            return new TreeSet<>(metadata.keySet());
+        }
+
+        @CheckForNull
+        @Override
+        public ConfigurationMetadata getConfigurationMetadata(String s) {
+            return metadata.get(s);
+        }
+    }
+}

--- a/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProviderTest.java
+++ b/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProviderTest.java
@@ -16,6 +16,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.caconfig.impl.metadata.AnnotationClassParser;
@@ -29,6 +30,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.PageManagerFactory;
 import com.day.cq.wcm.api.reference.Reference;
 import com.day.cq.wcm.api.reference.ReferenceProvider;
 import com.google.common.collect.ImmutableMap;
@@ -69,6 +72,11 @@ public class ConfigurationReferenceProviderTest {
         metadataProvider.addConfigurationClass(ConfigurationB.class);
 
         aemContext.registerInjectActivateService(new PagePersistenceStrategy(), "enabled", true);
+        aemContext.registerService(PageManagerFactory.class, new PageManagerFactory() {
+            @Override public PageManager getPageManager(ResourceResolver resourceResolver) {
+                return aemContext.pageManager();
+            }
+        });
         aemContext.registerService(ConfigurationMetadataProvider.class, metadataProvider);
 
         applyConfig(page1, "configA", configurationA); // 1 config on page1


### PR DESCRIPTION
This PR implements:

1) `PagePersistenceStrategy#deleteConfiguration()` using PageManager API, but falling back to the current behaviour in case the `Resource` cannot be adapted to `Page`. This as expected causes a Delete replication action when the content was published before.

2) `ConfigurationReferenceProvider` implementation of `ReferenceProvider` to return the reference context-aware configurations to the `ActivationReferenceSearchServlet` which allows the editor to publish the configurations along with the pages they are used in.