### PR TITLE
WCON-42: take inheritance into account for the ReferenceProvider

### DIFF
--- a/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProviderTest.java
+++ b/extensions/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProviderTest.java
@@ -87,13 +87,6 @@ public class ConfigurationReferenceProviderTest {
     metadataProvider.addConfigurationClass(ConfigurationB.class);
 
     aemContext.registerInjectActivateService(new PagePersistenceStrategy(), "enabled", true);
-    aemContext.registerService(PageManagerFactory.class, new PageManagerFactory() {
-
-      @Override
-      public PageManager getPageManager(ResourceResolver resourceResolver) {
-        return aemContext.pageManager();
-      }
-    });
     aemContext.registerService(ConfigurationMetadataProvider.class, metadataProvider);
 
     applyConfig(page1, "configA", CONFIGURATION_A); // 1 config on page1


### PR DESCRIPTION
This uses the approach of `ConfigurationManagerImpl` to resolve an inhertiance chain instead of using the primary resource only returned from `ConfigurationManagerImpl#getConfiguration()`.