### PR TITLE
Feature/wcon 75 provide spi for aem page context aware resource

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -60,13 +60,13 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.caconfig.spi</artifactId>
-      <version>1.3.2</version>
+      <version>1.4.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.caconfig.impl</artifactId>
-      <version>1.4.8</version>
+      <version>1.5.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/extensions/src/main/java/io/wcm/caconfig/extensions/bindings/impl/CurrentPageConfigurationBindingsResourceDetectionStrategy.java
+++ b/extensions/src/main/java/io/wcm/caconfig/extensions/bindings/impl/CurrentPageConfigurationBindingsResourceDetectionStrategy.java
@@ -1,0 +1,34 @@
+package io.wcm.caconfig.extensions.bindings.impl;
+
+import com.adobe.cq.sightly.WCMBindings;
+import com.day.cq.wcm.api.Page;
+import javax.script.Bindings;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.caconfig.resource.spi.ConfigurationBindingsResourceDetectionStrategy;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * AEM-specific configuration binding resource strategy that has higher precedence than the default strategy from Sling.
+ * <p>
+ * It uses the {@code WCMBindings.CURRENT_PAGE} binding instead of the default {@code SlingBindings.REQUEST} binding.
+ * </p>
+ */
+@Component(
+    service = ConfigurationBindingsResourceDetectionStrategy.class,
+    property = {
+        Constants.SERVICE_RANKING + "=200"
+    }
+)
+public class CurrentPageConfigurationBindingsResourceDetectionStrategy implements ConfigurationBindingsResourceDetectionStrategy {
+
+    @Override
+    public Resource detectResource(Bindings bindings) {
+        if (bindings.containsKey(WCMBindings.CURRENT_PAGE)) {
+            Page currentPage = (Page) bindings.get(WCMBindings.CURRENT_PAGE);
+            return currentPage.getContentResource();
+        }
+        return null;
+    }
+
+}

--- a/extensions/src/main/java/io/wcm/caconfig/extensions/bindings/impl/CurrentPageConfigurationBindingsResourceDetectionStrategy.java
+++ b/extensions/src/main/java/io/wcm/caconfig/extensions/bindings/impl/CurrentPageConfigurationBindingsResourceDetectionStrategy.java
@@ -11,7 +11,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * AEM-specific configuration binding resource strategy that has higher precedence than the default strategy from Sling.
  * <p>
- * It uses the {@code WCMBindings.CURRENT_PAGE} binding instead of the default {@code SlingBindings.REQUEST} binding.
+ * It uses the {@code WCMBindings.CURRENT_PAGE} binding instead of the default {@code SlingBindings.REQUEST} binding to detect the resource.
  * </p>
  */
 @Component(

--- a/extensions/src/main/java/io/wcm/caconfig/extensions/persistence/impl/ToolsConfigPagePersistenceStrategy.java
+++ b/extensions/src/main/java/io/wcm/caconfig/extensions/persistence/impl/ToolsConfigPagePersistenceStrategy.java
@@ -36,12 +36,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.apache.commons.collections.IteratorUtils;
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.collections.PredicateUtils;
-import org.apache.commons.collections.Transformer;
-import org.apache.commons.collections.iterators.FilterIterator;
-import org.apache.commons.collections.iterators.TransformIterator;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.collections4.PredicateUtils;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.iterators.FilterIterator;
+import org.apache.commons.collections4.iterators.TransformIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;

--- a/extensions/src/test/java/io/wcm/caconfig/extensions/bindings/impl/CurrentPageConfigurationBindingsResourceDetectionStrategyTest.java
+++ b/extensions/src/test/java/io/wcm/caconfig/extensions/bindings/impl/CurrentPageConfigurationBindingsResourceDetectionStrategyTest.java
@@ -1,0 +1,54 @@
+package io.wcm.caconfig.extensions.bindings.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+import com.adobe.cq.sightly.WCMBindings;
+import com.day.cq.wcm.api.Page;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import javax.script.Bindings;
+import org.apache.sling.api.resource.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(AemContextExtension.class)
+@ExtendWith(MockitoExtension.class)
+public class CurrentPageConfigurationBindingsResourceDetectionStrategyTest {
+
+    final AemContext context = new AemContext();
+
+    @Mock
+    private Page page;
+
+    @Mock
+    private Resource contentResource;
+
+    @Mock
+    private Bindings bindings;
+
+    private CurrentPageConfigurationBindingsResourceDetectionStrategy underTest;
+
+    @BeforeEach
+    void before() {
+        underTest = context.registerService(new CurrentPageConfigurationBindingsResourceDetectionStrategy());
+    }
+
+    @Test
+    void returnsNullWhenNoPagePresent() {
+        when(bindings.containsKey(WCMBindings.CURRENT_PAGE)).thenReturn(false);
+        assertNull(underTest.detectResource(bindings));
+    }
+
+    @Test
+    void returnsContentResourceWhenPageIsPresent() {
+        when(bindings.containsKey(WCMBindings.CURRENT_PAGE)).thenReturn(true);
+        when(bindings.get(WCMBindings.CURRENT_PAGE)).thenReturn(page);
+        when(page.getContentResource()).thenReturn(contentResource);
+        assertSame(contentResource, underTest.detectResource(bindings));
+    }
+}


### PR DESCRIPTION
Added a WCM CurrentPageConfigurationBindingsResourceDetectionStrategy to use the currentPage instead of the SlingHttpServletRequest resource

See also: https://issues.apache.org/jira/browse/SLING-8849

And the following Apache Sling pull requests:
- https://github.com/apache/sling-org-apache-sling-caconfig-spi/pull/1
- https://github.com/apache/sling-org-apache-sling-caconfig-impl/pull/3