### PR TITLE
clientlibs-root deployment pathchange

### DIFF
--- a/editor/bundle/pom.xml
+++ b/editor/bundle/pom.xml
@@ -163,7 +163,7 @@
           <bnd>
             Sling-Initial-Content: \
               SLING-INF/app-root;overwrite:=true;ignoreImportProviders:=xml;path:=/apps/wcm-io/caconfig/editor,\
-              SLING-INF/clientlibs-root;overwrite:=true;ignoreImportProviders:=xml;path:=/etc/clientlibs/wcm-io/caconfig/editor
+              SLING-INF/clientlibs-root;overwrite:=true;ignoreImportProviders:=xml;path:=/apps/clientlibs/wcm-io/caconfig/editor
 
             Sling-Model-Packages: \
               io.wcm.caconfig.editor.model


### PR DESCRIPTION
in AEM, app-root and clientlibs-root both should get deployed inside /apps folder.
clientlibs-root should get deployed in apps/clientlibs instead of /etc/clientlibs folder.