### PR TITLE
Show caconfigs that are only overridden globally

### DIFF
--- a/editor/bundle/src/main/java/io/wcm/caconfig/editor/impl/ConfigNamesServlet.java
+++ b/editor/bundle/src/main/java/io/wcm/caconfig/editor/impl/ConfigNamesServlet.java
@@ -161,7 +161,7 @@ public class ConfigNamesServlet extends SlingSafeMethodsServlet {
     else {
       ConfigurationData config = configManager.getConfiguration(contextResource, configName);
       if (config != null) {
-        result.exists = config.getResourcePath() != null;
+        result.exists = config.getResourcePath() != null || config.isOverridden();
         result.inherited = config.isInherited();
         result.overridden = config.isOverridden();
       }

--- a/editor/bundle/src/test/java/io/wcm/caconfig/editor/impl/ConfigNamesServletTest.java
+++ b/editor/bundle/src/test/java/io/wcm/caconfig/editor/impl/ConfigNamesServletTest.java
@@ -127,6 +127,26 @@ class ConfigNamesServletTest {
   }
 
   @Test
+  void testResponseWithOverriddenOnly() throws Exception {
+
+    when(configData.getResourcePath()).thenReturn(null);
+    when(configData.isInherited()).thenReturn(false);
+    when(configData.isOverridden()).thenReturn(true);
+
+    ConfigNamesServlet underTest = context.registerInjectActivateService(new ConfigNamesServlet());
+    underTest.doGet(context.request(), context.response());
+
+    assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+
+    String expectedJson = "{contextPath:'/context/path',configNames:["
+        + "{configName:'name2',label:'A-label2',collection=true,exists:true,inherited:false,overridden:true,allowAdd:true},"
+        + "{configName:'name1',label:'B-label1',description:'desc1',collection:false,exists:true,inherited:false,overridden:true,allowAdd:true},"
+        + "{configName:'name3',label:'C-label3',collection:false,exists:false,inherited:false,overridden:false,allowAdd:true}"
+        + "]}";
+    JSONAssert.assertEquals(expectedJson, context.response().getOutputAsString(), true);
+  }
+
+  @Test
   void testResponseWithFiltering() throws Exception {
     context.registerService(ConfigurationEditorFilter.class, new ConfigurationEditorFilter() {
       @Override

--- a/editor/changes.xml
+++ b/editor/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.8.4" date="not released">
+      <action type="fix" dev="sseifert">
+        Ensure a context-aware configuration appears in configuration overview in editor when it is overridden only globally, and no config data exists.
+      </action>
+    </release>
+
     <release version="1.8.2" date="2021-05-25">
       <action type="update" dev="dding" issue="WCON-72">
         Migrate front-end editor components to CoralUI 3 and remove dependency on CoralUI 2.

--- a/sample-app/bundles/core/src/main/java/io/wcm/caconfig/sample/config/ConfigOverrideSample.java
+++ b/sample-app/bundles/core/src/main/java/io/wcm/caconfig/sample/config/ConfigOverrideSample.java
@@ -1,0 +1,43 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2021 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caconfig.sample.config;
+
+import org.apache.sling.caconfig.annotation.Configuration;
+import org.apache.sling.caconfig.annotation.Property;
+
+/**
+ * Config annotation class example to test overrides.
+ */
+@Configuration(label = "Override Sample Configuration", description = "This is a sample configuration for testing overrides.")
+public @interface ConfigOverrideSample {
+
+  /**
+   * @return String parameter
+   */
+  @Property(label = "String Param", description = "This is a string parameter in the singleton configuration.", order = 1)
+  String stringParam();
+
+  /**
+   * @return Integer parameter
+   */
+  @Property(label = "Integer Param", order = 2)
+  int intParam();
+
+}

--- a/sample-app/config-definition/src/main/templates/sample-aem-cms/sample-aem-cms-config.provisioning.hbs
+++ b/sample-app/config-definition/src/main/templates/sample-aem-cms/sample-aem-cms-config.provisioning.hbs
@@ -19,7 +19,9 @@
   # Example for config override
   org.apache.sling.caconfig.impl.override.OsgiConfigurationOverrideProvider-caconfig-sample
     description="Override\ Example"
-    overrides=["[/content/contextaware-config-sample/en/sub-page/sub-page-override]io.wcm.caconfig.sample.config.ConfigSample\={\"stringParam\":\"override-stringParam\",\"intParam\":999}","[/content/contextaware-config-sample/en/sub-page/sub-page-override]sample/configuration/2/stringParam\=\"override2-stringParam\""]
+    overrides=["[/content/contextaware-config-sample/en/sub-page/sub-page-override]io.wcm.caconfig.sample.config.ConfigSample\={\"stringParam\":\"override-stringParam\",\"intParam\":999}",
+      "[/content/contextaware-config-sample/en/sub-page/sub-page-override]sample/configuration/2/stringParam\=\"override2-stringParam\"",
+      "io.wcm.caconfig.sample.config.ConfigOverrideSample\={\"stringParam\":\"global-override-stringParam\",\"intParam\":123}"]
     enabled=B"true"
 
   # Trace logging for Context-Aware Config


### PR DESCRIPTION
Ensure a context-aware configuration appears in configuration overview in editor when it is overridden only globally, and no config data exists.