### PR TITLE
Values entered in caconfig editor text field's should not be trimmed automatically.

### DIFF
--- a/editor/bundle/src/main/resources/angularjs-partials/multifield.html
+++ b/editor/bundle/src/main/resources/angularjs-partials/multifield.html
@@ -81,6 +81,7 @@
     <input is="coral-textfield" type="type"
            bo-if="type!=='checkbox'"
            ng-model="value.value"
+           ng-trim="false"
            ng-pattern="pattern" />
     <div class="coral-ButtonGroup _coral-ButtonGroup coral3-ButtonGroup">
       <button class="coral-ButtonGroup-item coral3-ButtonGroup-item caconfig-disableable-button"

--- a/editor/bundle/src/main/resources/angularjs-partials/propertyInputText.html
+++ b/editor/bundle/src/main/resources/angularjs-partials/propertyInputText.html
@@ -1,6 +1,6 @@
 <div>
   <input is="coral-textfield" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited"
-         ng-model="property.value"
+         ng-model="property.value" ng-trim="false"
          ng-pattern="pattern" />
   <input is="coral-textfield" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"
          ng-model="property.value"

--- a/editor/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
+++ b/editor/bundle/src/main/resources/angularjs-partials/propertyInputTextarea.html
@@ -1,6 +1,6 @@
 <div>
   <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-not-inherited"
-            ng-model="property.value"/>
+            ng-model="property.value" ng-trim="false"/>
   <textarea is="coral-textarea" class="caconfig-if-property-not-overridden-and-not-inherited caconfig-if-config-inherited"
             ng-model="property.value"
             disabled readonly />

--- a/editor/changes.xml
+++ b/editor/changes.xml
@@ -27,6 +27,9 @@
       <action type="fix" dev="sseifert">
         Ensure a context-aware configuration appears in configuration overview in editor when it is overridden only globally, and no config data exists.
       </action>
+      <action type="fix" dev="Srikanth.Gurram@aldi-sued.com">
+        Values entered in caconfig editor text field's should not be trimmed automatically.
+      </action>
     </release>
 
     <release version="1.8.2" date="2021-05-25">


### PR DESCRIPTION
- In the caconfig ALDI Project, two text fields can be entered: Page Title Prefix, Page Title Suffix

- For both it is important to have control over leading/trailing spaces at the beginning and end of the value to build a nice title

- But it seems the caconfig editor automatically applies a trim on the values when saving, so they are always lost - that should be fixed